### PR TITLE
Caution when enabling inertial separator

### DIFF
--- a/aircraft-tbm930-improvement/SimObjects/Airplanes/Asobo_TBM930/panel/panel.xml
+++ b/aircraft-tbm930-improvement/SimObjects/Airplanes/Asobo_TBM930/panel/panel.xml
@@ -615,9 +615,10 @@
     <Annunciation>
       <Type>Caution</Type>
       <Text>INERT SEP ON</Text>
-      <Condition>
-        <Simvar name="ENG ANTI ICE:1" unit="Bool"/>
-      </Condition>
+      <Greater>
+        <Simvar name="GENERAL ENG ANTI ICE POSITION:1" unit="number"/>
+        <Constant>0.874</Constant>
+      </Greater>
     </Annunciation>
 
     <Annunciation>


### PR DESCRIPTION
I had to go digging through documentation, but eventually found the right simvar. Note that it still thinks it's disabled, but it knows that it's partially enabled. 

Note: 
- In a future update (once INERT SEP FAILURE is a thing) this may cause problems. But it works for now.
- Starting the sim with the inertial separator enabled (such as on the runway), it will be fully enabled and not partially enabled.

screenshot from simvar explorer with inertial separator enabled:

![image](https://user-images.githubusercontent.com/1883296/95003106-f2896780-05db-11eb-8a5b-a05de5805c0b.png)
